### PR TITLE
websocket资源泄露问题修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <groupId>cn.xfyun</groupId>
     <artifactId>websdk-java-spark</artifactId>
     <!--请替换成最新稳定版本-->
-    <version>2.1.5</version>
+    <version>2.1.6</version>
 </dependency>
 ```
 
@@ -55,7 +55,7 @@
     <groupId>cn.xfyun</groupId>
     <artifactId>websdk-java-speech</artifactId>
     <!--请替换成最新稳定版本-->
-    <version>3.0.5</version>
+    <version>3.0.6</version>
 </dependency>
 ```
 重要版本更新说明
@@ -86,7 +86,7 @@
     <groupId>cn.xfyun</groupId>
     <artifactId>websdk-java-nlp</artifactId>
     <!--请替换成最新稳定版本-->
-    <version>2.0.9</version>
+    <version>2.0.10</version>
 </dependency>
 ```
 
@@ -105,7 +105,7 @@
     <groupId>cn.xfyun</groupId>
     <artifactId>websdk-java-ocr</artifactId>
     <!--请替换成最新稳定版本-->
-    <version>2.0.9</version>
+    <version>2.0.10</version>
 </dependency>
 ```
 
@@ -137,7 +137,7 @@
     <groupId>cn.xfyun</groupId>
     <artifactId>websdk-java-face-detector</artifactId>
     <!--请替换成最新稳定版本-->
-    <version>2.0.9</version>
+    <version>2.0.10</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>websdk-java</artifactId>
     <name>websdk-java</name>
     <packaging>pom</packaging>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
     
     <url>https://github.com/iFLYTEK-OP</url>
     <description>xfyun SDK</description>
@@ -69,12 +69,12 @@
         <powermock.version>2.0.2</powermock.version>
         <jacoco.version>0.8.7</jacoco.version>
         <!--子模块版本管理-->
-        <websdk-java-spark.version>2.1.5</websdk-java-spark.version>
-        <websdk-java-speech.version>3.0.5</websdk-java-speech.version>
-        <websdk-java-core.version>2.0.9</websdk-java-core.version>
-        <websdk-java-nlp.version>2.0.9</websdk-java-nlp.version>
-        <websdk-java-face-detector.version>2.0.9</websdk-java-face-detector.version>
-        <websdk-java-ocr.version>2.0.9</websdk-java-ocr.version>
+        <websdk-java-spark.version>2.1.6</websdk-java-spark.version>
+        <websdk-java-speech.version>3.0.6</websdk-java-speech.version>
+        <websdk-java-core.version>2.0.10</websdk-java-core.version>
+        <websdk-java-nlp.version>2.0.10</websdk-java-nlp.version>
+        <websdk-java-face-detector.version>2.0.10</websdk-java-face-detector.version>
+        <websdk-java-ocr.version>2.0.10</websdk-java-ocr.version>
     </properties>
 
     <build>

--- a/websdk-java-core/pom.xml
+++ b/websdk-java-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-face-detector/pom.xml
+++ b/websdk-java-face-detector/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-       <version>2.1.5</version>
+       <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-nlp/pom.xml
+++ b/websdk-java-nlp/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-nlp/src/main/java/cn/xfyun/service/simult/SimInterpWebSocketListener.java
+++ b/websdk-java-nlp/src/main/java/cn/xfyun/service/simult/SimInterpWebSocketListener.java
@@ -107,11 +107,18 @@ public abstract class SimInterpWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("webSocket connect failed .", t);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-nlp/src/main/java/cn/xfyun/service/simult/SimInterpWebSocketListener.java
+++ b/websdk-java-nlp/src/main/java/cn/xfyun/service/simult/SimInterpWebSocketListener.java
@@ -108,18 +108,16 @@ public abstract class SimInterpWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }
     }
-
 }

--- a/websdk-java-ocr/pom.xml
+++ b/websdk-java-ocr/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-       <version>2.1.5</version>
+       <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-ocr/src/main/java/cn/xfyun/service/document/AbstractPDRecWebSocketListener.java
+++ b/websdk-java-ocr/src/main/java/cn/xfyun/service/document/AbstractPDRecWebSocketListener.java
@@ -67,7 +67,11 @@ public abstract class AbstractPDRecWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -142,15 +146,14 @@ public abstract class AbstractPDRecWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-parent/pom.xml
+++ b/websdk-java-parent/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>websdk-java</artifactId>
         <groupId>cn.xfyun</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>websdk-java-parent</artifactId>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
 
     <dependencies>
         <dependency>

--- a/websdk-java-spark/pom.xml
+++ b/websdk-java-spark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/maas/AbstractMaasWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/maas/AbstractMaasWebSocketListener.java
@@ -60,7 +60,11 @@ public abstract class AbstractMaasWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -105,18 +109,16 @@ public abstract class AbstractMaasWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }
     }
-
 }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/maas/AbstractMaasWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/maas/AbstractMaasWebSocketListener.java
@@ -56,7 +56,12 @@ public abstract class AbstractMaasWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
-
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -99,11 +104,18 @@ public abstract class AbstractMaasWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("webSocket connect failed .", t);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/oral/AbstractOralWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/oral/AbstractOralWebSocketListener.java
@@ -84,7 +84,11 @@ public abstract class AbstractOralWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -154,15 +158,14 @@ public abstract class AbstractOralWebSocketListener extends WebSocketListener {
         super.onFailure(webSocket, t, response);
         logger.error("connection failed");
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/oral/AbstractOralWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/oral/AbstractOralWebSocketListener.java
@@ -80,6 +80,12 @@ public abstract class AbstractOralWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -147,10 +153,18 @@ public abstract class AbstractOralWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         logger.error("connection failed");
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/sparkiat/AbstractSparkIatWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/sparkiat/AbstractSparkIatWebSocketListener.java
@@ -60,7 +60,11 @@ public abstract class AbstractSparkIatWebSocketListener extends WebSocketListene
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -104,15 +108,14 @@ public abstract class AbstractSparkIatWebSocketListener extends WebSocketListene
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/sparkiat/AbstractSparkIatWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/sparkiat/AbstractSparkIatWebSocketListener.java
@@ -56,7 +56,12 @@ public abstract class AbstractSparkIatWebSocketListener extends WebSocketListene
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
-        logger.info("webSocket is open");
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -98,11 +103,18 @@ public abstract class AbstractSparkIatWebSocketListener extends WebSocketListene
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("webSocket connect failed .", t);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractImgUnderstandWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractImgUnderstandWebSocketListener.java
@@ -60,7 +60,11 @@ public abstract class AbstractImgUnderstandWebSocketListener extends WebSocketLi
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -104,15 +108,14 @@ public abstract class AbstractImgUnderstandWebSocketListener extends WebSocketLi
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractImgUnderstandWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractImgUnderstandWebSocketListener.java
@@ -56,7 +56,12 @@ public abstract class AbstractImgUnderstandWebSocketListener extends WebSocketLi
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
-        logger.info("webSocket is open");
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -98,11 +103,18 @@ public abstract class AbstractImgUnderstandWebSocketListener extends WebSocketLi
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("webSocket failed .", t);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractSparkModelWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/sparkmodel/AbstractSparkModelWebSocketListener.java
@@ -60,7 +60,11 @@ public abstract class AbstractSparkModelWebSocketListener extends WebSocketListe
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -104,15 +108,14 @@ public abstract class AbstractSparkModelWebSocketListener extends WebSocketListe
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-spark/src/main/java/cn/xfyun/service/voiceclone/AbstractVoiceCloneWebSocketListener.java
+++ b/websdk-java-spark/src/main/java/cn/xfyun/service/voiceclone/AbstractVoiceCloneWebSocketListener.java
@@ -84,7 +84,11 @@ public abstract class AbstractVoiceCloneWebSocketListener extends WebSocketListe
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -153,15 +157,14 @@ public abstract class AbstractVoiceCloneWebSocketListener extends WebSocketListe
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-speech/pom.xml
+++ b/websdk-java-speech/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>websdk-java-parent</artifactId>
         <groupId>cn.xfyun</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath>../websdk-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/iat/AbstractIatWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/iat/AbstractIatWebSocketListener.java
@@ -53,7 +53,11 @@ public abstract class AbstractIatWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -96,18 +100,16 @@ public abstract class AbstractIatWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }
     }
-
 }

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/iat/AbstractIatWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/iat/AbstractIatWebSocketListener.java
@@ -49,7 +49,12 @@ public abstract class AbstractIatWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
-
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -90,11 +95,18 @@ public abstract class AbstractIatWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("webSocket connect failed .", t);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/igr/AbstractIgrWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/igr/AbstractIgrWebSocketListener.java
@@ -33,7 +33,11 @@ public abstract class AbstractIgrWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -74,15 +78,14 @@ public abstract class AbstractIgrWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/igr/AbstractIgrWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/igr/AbstractIgrWebSocketListener.java
@@ -29,6 +29,12 @@ public abstract class AbstractIgrWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -67,10 +73,18 @@ public abstract class AbstractIgrWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/ise/AbstractIseWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/ise/AbstractIseWebSocketListener.java
@@ -30,7 +30,12 @@ public abstract class AbstractIseWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
-
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -69,10 +74,18 @@ public abstract class AbstractIseWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/ise/AbstractIseWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/ise/AbstractIseWebSocketListener.java
@@ -34,7 +34,11 @@ public abstract class AbstractIseWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -75,15 +79,14 @@ public abstract class AbstractIseWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/rta/AbstractRtasrWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/rta/AbstractRtasrWebSocketListener.java
@@ -66,6 +66,12 @@ public abstract class AbstractRtasrWebSocketListener extends WebSocketListener {
 	@Override
 	public void onOpen(WebSocket webSocket, Response response) {
 		super.onOpen(webSocket, response);
+		try {
+			logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+		} finally {
+			// 防止握手失败资源泄漏
+			response.close();
+		}
 	}
 
 	@Override
@@ -106,15 +112,23 @@ public abstract class AbstractRtasrWebSocketListener extends WebSocketListener {
 
 	@Override
 	public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
-		if (t instanceof EOFException) {
-			onClosed();
-		} else {
-			t.printStackTrace();
-			onFail(webSocket, t, response);
-		}
-		// 必须手动关闭 response 否则连接泄漏
-		if (response != null) {
-			response.close();
+		try {
+			// logger.error("webSocket connect failed .", t);
+			if (t instanceof EOFException) {
+				onClosed();
+			} else {
+				t.printStackTrace();
+				onFail(webSocket, t, response);
+			}
+		} finally {
+			// 必须手动关闭 response 否则连接泄漏
+			if (response != null) {
+				try {
+					response.close();
+				} catch (Exception closeError) {
+					logger.debug("response close failed", closeError);
+				}
+			}
 		}
 	}
 

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/rta/AbstractRtasrWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/rta/AbstractRtasrWebSocketListener.java
@@ -70,7 +70,11 @@ public abstract class AbstractRtasrWebSocketListener extends WebSocketListener {
 			logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
 		} finally {
 			// 防止握手失败资源泄漏
-			response.close();
+			try {
+				response.close();
+			} catch (Exception closeError) {
+				logger.warn("response close failed", closeError);
+			}
 		}
 	}
 
@@ -121,16 +125,14 @@ public abstract class AbstractRtasrWebSocketListener extends WebSocketListener {
 				onFail(webSocket, t, response);
 			}
 		} finally {
-			// 必须手动关闭 response 否则连接泄漏
+			// 手动关闭,防止连接泄漏
 			if (response != null) {
 				try {
 					response.close();
 				} catch (Exception closeError) {
-					logger.debug("response close failed", closeError);
+					logger.warn("response close failed", closeError);
 				}
 			}
 		}
 	}
-
-
 }

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/tts/AbstractTtsWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/tts/AbstractTtsWebSocketListener.java
@@ -73,7 +73,11 @@ public abstract class AbstractTtsWebSocketListener extends WebSocketListener {
             logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
         } finally {
             // 防止握手失败资源泄漏
-            response.close();
+            try {
+                response.close();
+            } catch (Exception closeError) {
+                logger.warn("response close failed", closeError);
+            }
         }
     }
 
@@ -136,15 +140,14 @@ public abstract class AbstractTtsWebSocketListener extends WebSocketListener {
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
         try {
-            // logger.error("webSocket connect failed .", t);
             onFail(webSocket, t, response);
         } finally {
-            // 必须手动关闭 response 否则连接泄漏
+            // 手动关闭,防止连接泄漏
             if (response != null) {
                 try {
                     response.close();
                 } catch (Exception closeError) {
-                    logger.debug("response close failed", closeError);
+                    logger.warn("response close failed", closeError);
                 }
             }
         }

--- a/websdk-java-speech/src/main/java/cn/xfyun/service/tts/AbstractTtsWebSocketListener.java
+++ b/websdk-java-speech/src/main/java/cn/xfyun/service/tts/AbstractTtsWebSocketListener.java
@@ -69,6 +69,12 @@ public abstract class AbstractTtsWebSocketListener extends WebSocketListener {
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
         super.onOpen(webSocket, response);
+        try {
+            logger.debug("Handshake success, code={}, headers={}", response.code(), response.headers());
+        } finally {
+            // 防止握手失败资源泄漏
+            response.close();
+        }
     }
 
     @Override
@@ -129,11 +135,18 @@ public abstract class AbstractTtsWebSocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
         super.onFailure(webSocket, t, response);
-        logger.error("connection failed");
-        onFail(webSocket, t, response);
-        // 必须手动关闭 response 否则连接泄漏
-        if (response != null) {
-            response.close();
+        try {
+            // logger.error("webSocket connect failed .", t);
+            onFail(webSocket, t, response);
+        } finally {
+            // 必须手动关闭 response 否则连接泄漏
+            if (response != null) {
+                try {
+                    response.close();
+                } catch (Exception closeError) {
+                    logger.debug("response close failed", closeError);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
websocket资源泄露问题修复:
1. onOpen回调方法的response参数握手失败导致资源泄露
2. onFailure毁掉方法的response参数不关闭导致资源泄露